### PR TITLE
#15 Create the deployment scripts for aws internal dns setup.

### DIFF
--- a/deployment/aws/envs/stage.json
+++ b/deployment/aws/envs/stage.json
@@ -1,5 +1,6 @@
 {
   "name": "bravehub-stage-stack",
+  "dnsSuffix": "bravehub-stage.com",
   "env": "stage",
   "cidrPrefix": "10.1",
   "routerInstanceType": "t2.micro",

--- a/deployment/aws/infra.yml
+++ b/deployment/aws/infra.yml
@@ -4,6 +4,9 @@ Parameters:
   StackName:
     Type: String
     Description: The cloudformation friendly name.
+  DnsSuffix:
+    Type: String
+    Description: The dns suffix used for creating multiple hosted zones required by the platform.
   BravehubEnv:
     Type: String
     Description: The bravehub environment we are currently creating.
@@ -136,6 +139,26 @@ Resources:
       DestinationCidrBlock: "0.0.0.0/0"
       RouteTableId: !Ref RegionalVpcRouterTable
       GatewayId: !Ref RegionalVpcIgw
+  RegionalVpcInternalApiDns:
+    Type: "AWS::Route53::HostedZone"
+    Properties:
+      HostedZoneConfig:
+        Comment: Internal api zone used for platform service discovery.
+      HostedZoneTags:
+        - Key: Name
+          Value: !Join [ "", [ "api.internal.", !Ref DnsSuffix, ".com" ] ]
+        - Key: "bravehub:vpc"
+          Value: !Ref RegionalVpc
+        - Key: "bravehub:stack"
+          Value: !Ref StackName
+        - Key: "bravehub:environment"
+          Value: !Ref BravehubEnv
+        - Key: "bravehub:layer"
+          Value: "internal-service-discovery"
+      Name: !Join [ "", [ "api.internal.", !Ref DnsSuffix ] ]
+      VPCs:
+        - VPCId: !Ref RegionalVpc
+          VPCRegion: !Ref "AWS::Region"
   RegionalVpcRouterSubnet1:
     Type: "AWS::EC2::Subnet"
     Properties:
@@ -242,6 +265,26 @@ Resources:
             Action: 
               - "sts:AssumeRole"
       Path: "/"
+      Policies:
+        - PolicyName: "ec2-permissions"
+          PolicyDocument:
+            Version : "2012-10-17"
+            Statement:
+              -
+                Effect: "Allow"
+                Action:
+                  - "ec2:DescribeInstances"
+                Resource: "*"
+        - PolicyName: "route53-permissions"
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              -
+                Effect: "Allow"
+                Action:
+                  - "route53:GetHostedZone"
+                  - "route53:ChangeResourceRecordSets"
+                Resource: !Join ["", [ "arn:aws:route53:::hostedzone/", !Ref RegionalVpcInternalApiDns ] ]
   RouterAutoScalingIamProfile:                
     Type: "AWS::IAM::InstanceProfile"
     Properties: 
@@ -273,9 +316,11 @@ Resources:
               - "cd /home/ubuntu"
               - !Join ["", [ "echo 'export ROLE=router'", " >> ", "/home/ubuntu/instance-descriptor.sh" ] ]
               - !Join ["", [ "echo 'export STACK_NAME=", !Ref StackName, "' >> ", "/home/ubuntu/instance-descriptor.sh" ] ]
+              - !Join ["", [ "echo 'export API_ZONE_ID=", !Ref RegionalVpcInternalApiDns, "' >> ", "/home/ubuntu/instance-descriptor.sh" ] ]
               - !Join ["", [ "aws s3 cp s3://", !Ref StackName, "/provisioning/bravehub-bootstrap.sh ."] ]
               - !Join ["", [ "aws s3 cp s3://", !Ref StackName, "/provisioning/bravehub.service ."] ]
               - "chmod u+x bravehub-bootstrap.sh"
+              - "chown -R ubuntu:ubuntu ."
               - "cp /home/ubuntu/bravehub.service /etc/systemd/user/bravehub.service"
               - "systemctl enable /etc/systemd/user/bravehub.service"
               - "systemctl daemon-reload"
@@ -338,9 +383,11 @@ Resources:
               - "cd /home/ubuntu"
               - !Join ["", [ "echo 'export ROLE=router'", " >> ", "/home/ubuntu/instance-descriptor.sh" ] ]
               - !Join ["", [ "echo 'export STACK_NAME=", !Ref StackName, "' >> ", "/home/ubuntu/instance-descriptor.sh" ] ]
+              - !Join ["", [ "echo 'export API_ZONE_ID=", !Ref RegionalVpcInternalApiDns, "' >> ", "/home/ubuntu/instance-descriptor.sh" ] ]
               - !Join ["", [ "aws s3 cp s3://", !Ref StackName, "/provisioning/bravehub-bootstrap.sh ."] ]
               - !Join ["", [ "aws s3 cp s3://", !Ref StackName, "/provisioning/bravehub.service ."] ]
               - "chmod u+x bravehub-bootstrap.sh"
+              - "chown -R ubuntu:ubuntu ."
               - "cp /home/ubuntu/bravehub.service /etc/systemd/user/bravehub.service"
               - "systemctl enable /etc/systemd/user/bravehub.service"
               - "systemctl daemon-reload"

--- a/deployment/aws/manage.sh
+++ b/deployment/aws/manage.sh
@@ -5,6 +5,7 @@ STACK_CONFIG_FILE=${1:-envs/stage.json}
 STACK_ACTION=${2:-update-stack}
 
 STACK_NAME=$(jq --raw-output .name ${STACK_CONFIG_FILE})
+STACK_DNS_SUFFIX=$(jq --raw-output .dnsSuffix ${STACK_CONFIG_FILE})
 STACK_ENV=$(jq --raw-output .env ${STACK_CONFIG_FILE})
 STACK_CIDR_PREFIX=$(jq --raw-output .cidrPrefix ${STACK_CONFIG_FILE})
 
@@ -34,6 +35,7 @@ echo "Stack name: ${STACK_NAME}"
 
 STACK_PARAMS=(
   ParameterKey=StackName,ParameterValue=${STACK_NAME}
+  ParameterKey=DnsSuffix,ParameterValue=${STACK_DNS_SUFFIX}
   ParameterKey=BravehubEnv,ParameterValue=${STACK_ENV}
   ParameterKey=StackCidrPrefix,ParameterValue=${STACK_CIDR_PREFIX}
   ParameterKey=RouterInstanceType,ParameterValue=${STACK_ROUTER_INSTANCE_TYPE}

--- a/deployment/provisioning/bravehub-bootstrap.sh
+++ b/deployment/provisioning/bravehub-bootstrap.sh
@@ -9,9 +9,11 @@ sudo apt-get install -y python-pip python-dev build-essential openssl libssl-dev
 sudo pip install --upgrade pip
 sudo pip install virtualenv
 
+rm -Rf provisioning
 mkdir provisioning
 cd provisioning
 aws s3 cp s3://${STACK_NAME}/provisioning/requirements.txt .
+aws s3 cp --recursive s3://${STACK_NAME}/provisioning/inventory inventory/
 aws s3 cp --recursive s3://${STACK_NAME}/provisioning/roles roles/
 aws s3 cp s3://${STACK_NAME}/provisioning/${ROLE}.yml .
 
@@ -19,4 +21,4 @@ virtualenv venv
 . venv/bin/activate
 pip install -r requirements.txt
 
-ansible-playbook -i "localhost," -c local -v ${ROLE}.yml
+ansible-playbook -i inventory/local -v ${ROLE}.yml

--- a/deployment/provisioning/bravehub.service
+++ b/deployment/provisioning/bravehub.service
@@ -3,6 +3,8 @@ Description=Bravehub bootstrap service responsible for provisioning the current 
 Requires=network.target
 
 [Service]
+User=ubuntu
+Group=ubuntu
 Type=oneshot
 EnvironmentFile=-/home/ubuntu/instance-descriptor.sh
 ExecStart=/home/ubuntu/bravehub-bootstrap.sh ${STACK_NAME} ${ROLE}

--- a/deployment/provisioning/inventory/local
+++ b/deployment/provisioning/inventory/local
@@ -1,0 +1,6 @@
+local:
+  hosts:
+    127.0.0.1:
+      ansible_connection: local
+      home_folder: /home/ubuntu
+      dns_ttl: 30

--- a/deployment/provisioning/roles/aws/tasks/main.yml
+++ b/deployment/provisioning/roles/aws/tasks/main.yml
@@ -8,3 +8,13 @@
     state: present
   tags:
     - aws
+
+- name: Add jq package.
+  become: yes
+  become_user: root
+  become_method: sudo
+  apt:
+    name: jq
+    state: present
+  tags:
+    - aws

--- a/deployment/provisioning/roles/router-setup/tasks/main.yml
+++ b/deployment/provisioning/roles/router-setup/tasks/main.yml
@@ -1,0 +1,47 @@
+---
+- name: Obtain AWS_REGION.
+  shell: curl http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/.$//'
+  register: AWS_REGION
+  tags:
+    - router-setup
+    - router-dns-setup
+
+- name: Obtain API_ZONE_NAME.
+  shell: . {{home_folder}}/instance-descriptor.sh && aws route53 get-hosted-zone --id ${API_ZONE_ID} | jq .HostedZone.Name | sed 's/\"//' | sed 's/\"//' | sed 's/.$//'
+  register: API_ZONE_NAME
+  tags:
+    - router-setup
+    - router-dns-setup
+
+- name: Remove previously saved API_ZONE_NAME.
+  shell: sed -i 's/export API_ZONE_NAME=.*//' {{home_folder}}/instance-descriptor.sh
+  tags:
+    - router-setup
+    - router-dns-setup
+
+- name: Persist API_ZONE_NAME.
+  shell: echo "export API_ZONE_NAME={{API_ZONE_NAME.stdout}}" >> {{home_folder}}/instance-descriptor.sh
+  tags:
+    - router-setup
+    - router-dns-setup
+
+- name: Obtain all routers ips.
+  shell: export AWS_DEFAULT_REGION={{AWS_REGION.stdout}} && . {{home_folder}}/instance-descriptor.sh && aws ec2 describe-instances --filters "Name=tag:bravehub:layer,Values=routing-api-gateway" --filters "Name=tag:bravehub:stack,Values=${STACK_NAME}" --filters "Name=instance-state-name,Values=running" | jq -r '.Reservations[].Instances[].NetworkInterfaces[0].PrivateIpAddress'
+  register: ROUTER_IPS
+  tags:
+    - router-setup
+    - router-dns-setup
+
+- name: Configure record set json input.
+  template:
+    src: "router-dns.json.j2"
+    dest: "{{home_folder}}/router-dns.json"
+  tags:
+    - router-setup
+    - router-dns-setup
+
+- name: Upsert the internal router dns record set.
+  shell: . {{home_folder}}/instance-descriptor.sh && aws route53 change-resource-record-sets --hosted-zone-id ${API_ZONE_ID} --change-batch file://{{home_folder}}/router-dns.json
+  tags:
+    - router-setup
+    - router-dns-setup

--- a/deployment/provisioning/roles/router-setup/templates/router-dns.json.j2
+++ b/deployment/provisioning/roles/router-setup/templates/router-dns.json.j2
@@ -1,0 +1,22 @@
+{
+  "Comment": "Update the router settings",
+  "Changes": [
+    {
+      "Action": "UPSERT",
+      "ResourceRecordSet": {
+        "Name": "router.{{API_ZONE_NAME.stdout}}",
+        "Type": "A",
+        "SetIdentifier": "router.{{API_ZONE_NAME.stdout}}",
+        "TTL": {{dns_ttl}},
+        "Region": "{{AWS_REGION.stdout}}",
+        "ResourceRecords": [
+          {% for router_ip in ROUTER_IPS.stdout_lines %}
+          {
+            "Value": "{{router_ip}}"
+          }{% if not loop.last %},{% endif %}
+          {% endfor %}
+        ]
+      }
+    }
+  ]
+}

--- a/deployment/provisioning/router.yml
+++ b/deployment/provisioning/router.yml
@@ -3,3 +3,4 @@
   roles:
     - aws
     - docker-setup
+    - router-setup


### PR DESCRIPTION
We now have support the internal dns resolution. The current PR makes the router.api.internal.<stck dns suffix> available. All internal traffic generated by api to api communication will go through the records registered in dns.