### PR TITLE
#29 Create the hbase bravehub schema during production cluster setup.

### DIFF
--- a/deployment/aws/infra.yml
+++ b/deployment/aws/infra.yml
@@ -567,7 +567,7 @@ Resources:
         - IpProtocol: tcp
           FromPort: 22
           ToPort: 22
-          CidrIp: 213.233.85.197/32
+          CidrIp: 188.27.206.11/32
       SecurityGroupEgress:
         - IpProtocol: tcp
           FromPort: 0

--- a/deployment/bravehub/Dockerfile
+++ b/deployment/bravehub/Dockerfile
@@ -1,6 +1,7 @@
-FROM bravehub_hbase-regionserver-1.api.internal.bravehub-dev.com:latest
+FROM bravehub/hbase:0.1.0
 
 USER root
+ADD scripts /root/scripts
 RUN cd /root && \
     echo "export JAVA_HOME=/usr/lib/jvm/default-jvm" >> "/root/.bashrc"
 

--- a/deployment/provisioning/bravehub-bootstrap.sh
+++ b/deployment/provisioning/bravehub-bootstrap.sh
@@ -3,11 +3,11 @@ set -eo pipefail
 
 . instance-descriptor.sh
 
-export LC_ALL=C
+export LC_ALL="en_US.UTF-8"
+export LC_CTYPE="en_US.UTF-8"
+sudo dpkg-reconfigure -f noninteractive locales
 sudo apt-get update -y
-sudo apt-get install -y python-pip python-dev build-essential openssl libssl-dev awscli
-sudo pip install --upgrade pip
-sudo pip install virtualenv
+sudo apt-get install -y python-pip python-dev python3-pip python3-dev python3-venv python3-apt build-essential openssl libssl-dev awscli
 
 rm -Rf provisioning
 mkdir provisioning
@@ -18,8 +18,10 @@ aws s3 cp --recursive s3://${STACK_NAME}/provisioning/inventory inventory/
 aws s3 cp --recursive s3://${STACK_NAME}/provisioning/roles roles/
 aws s3 cp s3://${STACK_NAME}/provisioning/${ROLE}.yml .
 
-virtualenv venv
+python3 -m venv venv
 . venv/bin/activate
+pip install --upgrade pip
+cp -R /usr/lib/python3/dist-packages/apt* venv/lib/python3.*/site-packages/
 pip install -r requirements.txt
 
-ansible-playbook -i inventory/local -v ${ROLE}.yml
+ansible-playbook -i inventory/local -v -e "ansible_python_interpreter=$(pwd)/venv/bin/python3" ${ROLE}.yml

--- a/deployment/provisioning/build-images.sh
+++ b/deployment/provisioning/build-images.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+ZOOKEEPER_VERSION=0.1.0
+HBASE_VERSION=0.1.0
+BRAVEHUB_VERSION=0.1.0
+
+WORKDIR=$(pwd)
+
+rm -Rf images/*.tar
+
+ZOOKEEPER_IMAGE_NAME="bravehub/zookeeper:${ZOOKEEPER_VERSION}"
+cd ../hadoop/zookeeper && docker build -t ${ZOOKEEPER_IMAGE_NAME} -f Dockerfile .
+docker save ${ZOOKEEPER_IMAGE_NAME} -o ${WORKDIR}/images/zookeeper-${ZOOKEEPER_VERSION}.tar
+
+cd ${WORKDIR}
+HBASE_IMAGE_NAME="bravehub/hbase:${HBASE_VERSION}"
+cd ../hadoop/hbase && docker build -t ${HBASE_IMAGE_NAME} -f Dockerfile .
+docker save ${HBASE_IMAGE_NAME} -o ${WORKDIR}/images/hbase-${HBASE_VERSION}.tar
+
+cd ${WORKDIR}
+SETUP_DATABASE_IMAGE_NAME="bravehub/setup-database:${BRAVEHUB_VERSION}"
+cd ../bravehub && docker build -t ${SETUP_DATABASE_IMAGE_NAME} -f Dockerfile .
+docker save ${SETUP_DATABASE_IMAGE_NAME} -o ${WORKDIR}/images/setup-database-${BRAVEHUB_VERSION}.tar

--- a/deployment/provisioning/images/README.md
+++ b/deployment/provisioning/images/README.md
@@ -7,3 +7,5 @@ docker save <imageid>:<image-version> -o <image-name>-<image-version>.tar
 
 All images from here are imported automatically on every instance from the platform. This allows us to make deployments without actually using
 a docker repository.
+
+You can also use the **../provisioning/build-images.sh** script which populates this folder with all required images from production.

--- a/deployment/provisioning/inventory/local
+++ b/deployment/provisioning/inventory/local
@@ -27,3 +27,4 @@ local:
       hbase_thrift_infoport: 9100
       router_balanced_name: "router"
       router_instance_role: "routing-api-gateway"
+      bravehub_version: 0.1.0

--- a/deployment/provisioning/requirements.txt
+++ b/deployment/provisioning/requirements.txt
@@ -1,2 +1,4 @@
 ansible==2.3.2.0
 dnspython==1.15.0
+docker==2.5.0
+docker-compose==1.16.0rc1

--- a/deployment/provisioning/roles/bravehub-db-setup/tasks/main.yml
+++ b/deployment/provisioning/roles/bravehub-db-setup/tasks/main.yml
@@ -1,0 +1,32 @@
+---
+- name: Setup awscli.
+  include_role:
+    name: aws
+    tasks_from: awscli-configure
+  tags:
+    - bravehub-db-setup
+
+- name: Obtain the hbase site configuration.
+  become: yes
+  become_user: root
+  become_method: sudo
+  shell: base64 "{{hbase_home}}/hbase-site-master.xml"
+  register: HBASE_SITE_CONFIG
+  tags:
+    - bravehub-db-setup
+
+- set_fact:
+    HBASE_SITE_CONFIG: "{{HBASE_SITE_CONFIG.stdout}}"
+
+- name: Run the setup db docker image.
+  become: yes
+  become_user: root
+  become_method: sudo
+  docker_container:
+    name: bravehub
+    image: "bravehub/setup-database:{{bravehub_version}}"
+    env:
+      HBASE_SITE_CONFIG: "{{HBASE_SITE_CONFIG}}"
+      SCRIPT_NAME: "~/scripts/hbase/00-create-data-model.txt"
+  tags:
+    - bravehub-db-setup

--- a/deployment/provisioning/router.yml
+++ b/deployment/provisioning/router.yml
@@ -10,3 +10,4 @@
     - hbase-master-setup
     - hbase-regionserver-setup
     - hbase-thrift-setup
+    - bravehub-db-setup


### PR DESCRIPTION
The bravehub schema is now setup correctly during cluster bootstrap. Moreover, because we start the schema setup docker image from ansible using docker_container plugin we had to migrate to python3.